### PR TITLE
Implementing FabricManager Reboot operation

### DIFF
--- a/fm/fm.go
+++ b/fm/fm.go
@@ -30,6 +30,7 @@ type FabricManager interface {
 	PowerOn(machineUUID, tenantId, bearerToken string) error
 	PowerOff(machineUUID, tenantId, bearerToken string) error
 	GracefulShutdown(machineUUID, tenantId, bearerToken string) error
+	Reboot(machineUUID, tenantId, bearerToken string) error
 	ImageInstall(tenantId string, ssdId string, imageFilename, bearerToken string) error
 	RemoveMachine(machineUUID, tenantId, bearerToken string) error
 	CreateMachine(machineName, tenantId string, machineSpecs models.MachineSpecsArgs, bearerToken string) (string, error)
@@ -133,6 +134,24 @@ func (fmc *FabricManagerClient) GracefulShutdown(machineUUID, tenantId, bearerTo
 
 	slog.Info("Successfully requested graceful shutdown", "machine_uuid", machineUUID, "tenant_id", tenantId, "status_code", statusCode)
 
+	return nil
+}
+
+func (fmc *FabricManagerClient) Reboot(machineUUID, tenantId, bearerToken string) error {
+
+	endpoint := fmt.Sprintf("/machines/%s/reboot", machineUUID)
+	queryParams := map[string]string{"tenant_uuid": tenantId}
+	headers := httputils.GetAuthorizationHeaderWithContentType(bearerToken)
+	payload := []byte{}
+
+	statusCode, err := fmc.cdiClient.Put(payload, endpoint, queryParams, nil, headers)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Request PUT %s failed", endpoint), "err", err)
+		return err
+	}
+
+	slog.Info("Successfully requested machine reboot", "machine_uuid", machineUUID, "tenant_id", tenantId, "status_code", statusCode)
+	
 	return nil
 }
 

--- a/fm/fm_test.go
+++ b/fm/fm_test.go
@@ -583,6 +583,54 @@ func TestGracefulShutdownFailed(t *testing.T) {
 	assert.EqualError(t, err, "Request failed")
 }
 
+func TestRebootSuccess(t *testing.T) {
+	mockClient := httputils.NewMockCdiHTTPClient(t)
+	fmc := &FabricManagerClient{cdiClient: mockClient}
+
+	tenantId := "cdi-test"
+	machineId := "cdd792f2-5591-4c18-a8bd-1c39e55dedfa"
+
+	expectedQuery := map[string]string{"tenant_uuid": tenantId}
+	expectedHeaders := map[string]string{
+		"Content-Type": "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", models.AccessTokenExample),
+	}
+	expectedEndpoint := fmt.Sprintf("/machines/%s/reboot", machineId)
+	expectedPayload := []byte{}
+
+	mockClient.EXPECT().
+		Put(expectedPayload, expectedEndpoint, expectedQuery, nil, expectedHeaders).
+		Return(http.StatusOK, nil)
+
+	err := fmc.Reboot(machineId, tenantId, models.AccessTokenExample)
+	assert.NoError(t, err)
+}
+
+func TestRebootFailed(t *testing.T) {
+	mockClient := httputils.NewMockCdiHTTPClient(t)
+	fmc := &FabricManagerClient{cdiClient: mockClient}
+
+	tenantId := "cdi-test"
+	machineId := "cdd792f2-5591-4c18-a8bd-1c39e55dedfa"
+
+	expectedQuery := map[string]string{"tenant_uuid": tenantId}
+	expectedHeaders := map[string]string{
+		"Content-Type": "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", models.AccessTokenExample),
+	}
+	expectedEndpoint := fmt.Sprintf("/machines/%s/reboot", machineId)
+	expectedPayload := []byte{}
+
+	mockError := errors.New("Request failed")
+	mockClient.EXPECT().
+		Put(expectedPayload, expectedEndpoint, expectedQuery, nil, expectedHeaders).
+		Return(http.StatusInternalServerError, mockError)
+
+	err := fmc.Reboot(machineId, tenantId, models.AccessTokenExample)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Request failed")
+}
+
 func TestImageInstallSuccess(t *testing.T) {
 	mockClient := httputils.NewMockCdiHTTPClient(t)
 	fmc := &FabricManagerClient{cdiClient: mockClient}

--- a/fm/mock/mock_FabricManager.go
+++ b/fm/mock/mock_FabricManager.go
@@ -201,6 +201,54 @@ func (_c *MockFabricManager_GracefulShutdown_Call) RunAndReturn(run func(string,
 	return _c
 }
 
+// Reboot provides a mock function with given fields: machineUUID, tenantId, bearerToken
+func (_m *MockFabricManager) Reboot(machineUUID string, tenantId string, bearerToken string) error {
+	ret := _m.Called(machineUUID, tenantId, bearerToken)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reboot")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(machineUUID, tenantId, bearerToken)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockFabricManager_Reboot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reboot'
+type MockFabricManager_Reboot_Call struct {
+	*mock.Call
+}
+
+// Reboot is a helper method to define mock.On call
+//   - machineUUID string
+//   - tenantId string
+//   - bearerToken string
+func (_e *MockFabricManager_Expecter) Reboot(machineUUID interface{}, tenantId interface{}, bearerToken interface{}) *MockFabricManager_Reboot_Call {
+	return &MockFabricManager_Reboot_Call{Call: _e.mock.On("Reboot", machineUUID, tenantId, bearerToken)}
+}
+
+func (_c *MockFabricManager_Reboot_Call) Run(run func(machineUUID string, tenantId string, bearerToken string)) *MockFabricManager_Reboot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockFabricManager_Reboot_Call) Return(_a0 error) *MockFabricManager_Reboot_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockFabricManager_Reboot_Call) RunAndReturn(run func(string, string, string) error) *MockFabricManager_Reboot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ImageInstall provides a mock function with given fields: tenantId, ssdId, imageFilename, bearerToken
 func (_m *MockFabricManager) ImageInstall(tenantId string, ssdId string, imageFilename string, bearerToken string) error {
 	ret := _m.Called(tenantId, ssdId, imageFilename, bearerToken)

--- a/pkg/drivers/fsas/fsas.go
+++ b/pkg/drivers/fsas/fsas.go
@@ -929,7 +929,7 @@ func (d *Driver) Remove() error {
 
 // Restart a host using Fabric Manager reboot operation.
 func (d *Driver) Restart() error {
-	slog.Debug("Try to restart host")
+	slog.Debug("Attempting to restart host")
 	slog.Debug(fmt.Sprintf("BaseDriver struct: %+v", d.BaseDriver))
 	slog.Debug(fmt.Sprintf("Driver struct: %+v", d))
 

--- a/pkg/drivers/fsas/fsas.go
+++ b/pkg/drivers/fsas/fsas.go
@@ -927,7 +927,9 @@ func (d *Driver) Remove() error {
 	return nil
 }
 
-// Restart a host using Fabric Manager reboot operation.
+// Restart requests a host restart using Fabric Manager reboot operation.
+// The method returns after Fabric Manager accepts the reboot request.
+// It does not wait until the node finishes rebooting or becomes SSH-ready.
 func (d *Driver) Restart() error {
 	slog.Debug("Attempting to restart host")
 	slog.Debug(fmt.Sprintf("BaseDriver struct: %+v", d.BaseDriver))
@@ -937,46 +939,17 @@ func (d *Driver) Restart() error {
 		return err
 	}
 
-	// error MachineUUID is empty
 	if d.MachineUUID == "" {
 		slog.Error("Machine's UUID was unexpectedly empty", "machine_name", d.MachineName)
 		return fmt.Errorf("machine uuid is empty")
 	}
 
-	rebootErrCh := make(chan error, 1)
-	go func() {
-		token := d.Keycloak.GetToken()
-		rebootErrCh <- d.FabricManager.Reboot(d.MachineUUID, d.TenantUuid, token)
-	}()
-
-	slog.Info("Waiting for status", "status", BOOTING)
-	if err := d.waitForStatus(BOOTING, WAIT_FOR_STATUS_STEP, WAIT_FOR_STATUS_TIMEOUT); err != nil {
-		rebootErr := <-rebootErrCh
-		if rebootErr != nil {
-			slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", rebootErr)
-			return rebootErr
-		}
-		slog.Error("Error occurred during waitForStatus execution", "status", BOOTING, "err", err)
-		return err
-	}
-
-	slog.Info("Waiting for status", "status", ACTIVE_PON)
-	if err := d.waitForStatus(ACTIVE_PON, WAIT_FOR_STATUS_STEP, WAIT_FOR_STATUS_TIMEOUT); err != nil {
-		rebootErr := <-rebootErrCh
-		if rebootErr != nil {
-			slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", rebootErr)
-			return rebootErr
-		}
-		slog.Error("Error occurred during waitForStatus execution", "status", ACTIVE_PON, "err", err)
-		return err
-	}
-
-	if err := <-rebootErrCh; err != nil {
+	if err := d.FabricManager.Reboot(d.MachineUUID, d.TenantUuid, d.Keycloak.GetToken()); err != nil {
 		slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", err)
 		return err
 	}
 
-	slog.Info("Successfully restarted machine", "machineUUID", d.MachineUUID)
+	slog.Info("Successfully requested machine restart", "machineUUID", d.MachineUUID)
 	return nil
 }
 

--- a/pkg/drivers/fsas/fsas.go
+++ b/pkg/drivers/fsas/fsas.go
@@ -927,24 +927,34 @@ func (d *Driver) Remove() error {
 	return nil
 }
 
-// Restart a host. This may just call Stop(); Start() if the provider does not
-// have any special restart behaviour.
+// Restart a host using Fabric Manager reboot operation.
 func (d *Driver) Restart() error {
-	slog.Debug("Restarting host", "machineName", d.MachineName)
+	slog.Debug("Try to restart host")
+	slog.Debug(fmt.Sprintf("BaseDriver struct: %+v", d.BaseDriver))
+	slog.Debug(fmt.Sprintf("Driver struct: %+v", d))
 
-	slog.Debug("Attempting to Stop", "machineName", d.MachineName)
-	if err := d.Stop(); err != nil {
-		slog.Error("Issue during attempt to Stop the host", "err", err)
+	if err := d.initClients(); err != nil {
 		return err
 	}
 
-	slog.Debug("Attempting to Start", "machineName", d.MachineName)
-	if err := d.Start(); err != nil {
-		slog.Error("Issue during attempt to Start the host", "err", err)
+	// error MachineUUID is empty
+	if d.MachineUUID == "" {
+		slog.Error("Machine's UUID was unexpectedly empty", "machine_name", d.MachineName)
+		return fmt.Errorf("machine uuid is empty")
+	}
+
+	if err := d.FabricManager.Reboot(d.MachineUUID, d.TenantUuid, d.Keycloak.GetToken()); err != nil {
+		slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", err)
 		return err
 	}
 
-	slog.Info("Successfully restarted host", "machineName", d.MachineName)
+	slog.Info("Waiting for status", "status", ACTIVE_PON)
+	if err := d.waitForStatus(ACTIVE_PON, WAIT_FOR_STATUS_STEP, WAIT_FOR_STATUS_TIMEOUT); err != nil {
+		slog.Error("Error occurred during waitForStatus execution", "err", err)
+		return err
+	}
+
+	slog.Info("Successfully restarted machine", "machineUUID", d.MachineUUID)
 	return nil
 }
 

--- a/pkg/drivers/fsas/fsas.go
+++ b/pkg/drivers/fsas/fsas.go
@@ -943,14 +943,36 @@ func (d *Driver) Restart() error {
 		return fmt.Errorf("machine uuid is empty")
 	}
 
-	if err := d.FabricManager.Reboot(d.MachineUUID, d.TenantUuid, d.Keycloak.GetToken()); err != nil {
-		slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", err)
+	rebootErrCh := make(chan error, 1)
+	go func() {
+		token := d.Keycloak.GetToken()
+		rebootErrCh <- d.FabricManager.Reboot(d.MachineUUID, d.TenantUuid, token)
+	}()
+
+	slog.Info("Waiting for status", "status", BOOTING)
+	if err := d.waitForStatus(BOOTING, WAIT_FOR_STATUS_STEP, WAIT_FOR_STATUS_TIMEOUT); err != nil {
+		rebootErr := <-rebootErrCh
+		if rebootErr != nil {
+			slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", rebootErr)
+			return rebootErr
+		}
+		slog.Error("Error occurred during waitForStatus execution", "status", BOOTING, "err", err)
 		return err
 	}
 
 	slog.Info("Waiting for status", "status", ACTIVE_PON)
 	if err := d.waitForStatus(ACTIVE_PON, WAIT_FOR_STATUS_STEP, WAIT_FOR_STATUS_TIMEOUT); err != nil {
-		slog.Error("Error occurred during waitForStatus execution", "err", err)
+		rebootErr := <-rebootErrCh
+		if rebootErr != nil {
+			slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", rebootErr)
+			return rebootErr
+		}
+		slog.Error("Error occurred during waitForStatus execution", "status", ACTIVE_PON, "err", err)
+		return err
+	}
+
+	if err := <-rebootErrCh; err != nil {
+		slog.Error("Could not reboot Machine", "machineUUID", d.MachineUUID, "err", err)
 		return err
 	}
 

--- a/pkg/drivers/fsas/fsas_test.go
+++ b/pkg/drivers/fsas/fsas_test.go
@@ -2124,20 +2124,16 @@ func TestRestartSuccess(t *testing.T) {
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	// Stop
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, mockKeycloak.GetToken()).Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 15, nil).Once()
-	mockFM.On("GracefulShutdown", driver.MachineUUID, "", models.AccessTokenExample).Return(nil)
-
-	// Start
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 13, nil).Once()
-	mockFM.On("PowerOn", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
+		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 13, nil).Once()
 
 	err := driver.Restart()
 	assert.NoError(t, err)
 
 }
 
-func TestRestartFail_Stop(t *testing.T) {
+func TestRestartFailReboot(t *testing.T) {
 	mockFM := fmmock.NewMockFabricManager(t)
 	mockKeycloak := keycloakMock.NewMockKeycloak(t)
 
@@ -2155,25 +2151,14 @@ func TestRestartFail_Stop(t *testing.T) {
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	// No Start on Stop Failure
-
-	// Stop Fail - FM
-	shutdownError := fmt.Errorf("FM graceful shutdown failed")
-	mockFM.On("GracefulShutdown", driver.MachineUUID, "", models.AccessTokenExample).Return(shutdownError).Once()
+	rebootError := fmt.Errorf("FM reboot failed")
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(rebootError).Once()
 
 	err := driver.Restart()
-	assert.ErrorIs(t, err, shutdownError)
-
-	// Stop Fail - Status
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, mockKeycloak.GetToken()).Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil).Once()
-	mockFM.On("GracefulShutdown", driver.MachineUUID, "", models.AccessTokenExample).Return(nil).Once()
-
-	err = driver.Restart()
-	assert.ErrorContains(t, err, "required status was not achieved within the specified time")
-
+	assert.ErrorIs(t, err, rebootError)
 }
 
-func TestRestartFail_Start(t *testing.T) {
+func TestRestartFailWaitForStatus(t *testing.T) {
 	mockFM := fmmock.NewMockFabricManager(t)
 	mockKeycloak := keycloakMock.NewMockKeycloak(t)
 
@@ -2191,20 +2176,9 @@ func TestRestartFail_Start(t *testing.T) {
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	// Stop
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, mockKeycloak.GetToken()).Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 15, nil)
-	// Normal UUID
-	mockFM.On("GracefulShutdown", driver.MachineUUID, "", models.AccessTokenExample).Return(nil).Once()
-	// Empty UUID
-	mockFM.On("GracefulShutdown", "", "", models.AccessTokenExample).Return(nil).Maybe()
-
-	// Start Fail - Status
-	// mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).Return(
-	// 	models.ExpectedLanports,
-	// 	"902cc002-3775-4be0-be00-535a677b2ab4",
-	// 	987,
-	// 	nil)
-	mockFM.On("PowerOn", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
+		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil)
 
 	mockClock := timeutilsmock.NewMockClock(t)
 	statusClock = mockClock
@@ -2215,17 +2189,31 @@ func TestRestartFail_Start(t *testing.T) {
 	err := driver.Restart()
 
 	assert.Error(t, err)
-	errorData := "error: required status was not achieved within the specified time"
-	assert.EqualError(t, err, errorData)
+	assert.EqualError(t, err, "error: required status was not achieved within the specified time")
+}
 
-	// Start Fail - Empty UUID
-	driver.MachineUUID = ""
+func TestRestartFailEmptyMachineUUID(t *testing.T) {
+	mockFM := fmmock.NewMockFabricManager(t)
+	mockKeycloak := keycloakMock.NewMockKeycloak(t)
 
-	err = driver.Restart()
+	driver := &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			IPAddress: "10.1.2.3",
+			SSHUser:   "user-1",
+		},
+		SSHPassword:   "password1",
+		MachineUUID:   "",
+		FabricManager: mockFM,
+		Keycloak:      mockKeycloak,
+	}
+
+	mockKeycloak.On("IsInit").Return(true)
+	mockFM.On("IsInit").Return(true)
+
+	err := driver.Restart()
 
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "machine uuid is empty")
-
 }
 
 func TestAssignIpAddressesSuccess(t *testing.T) {

--- a/pkg/drivers/fsas/fsas_test.go
+++ b/pkg/drivers/fsas/fsas_test.go
@@ -2124,9 +2124,11 @@ func TestRestartSuccess(t *testing.T) {
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil).Once()
 	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
-		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 13, nil).Once()
+		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", int(BOOTING), nil).Once()
+	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
+		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", int(ACTIVE_PON), nil).Once()	
 
 	err := driver.Restart()
 	assert.NoError(t, err)
@@ -2154,6 +2156,15 @@ func TestRestartFailReboot(t *testing.T) {
 	rebootError := fmt.Errorf("FM reboot failed")
 	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(rebootError).Once()
 
+	mockClock := timeutilsmock.NewMockClock(t)
+	statusClock = mockClock
+	mock_now_time := time.Date(2025, time.January, 1, 12, 0, 0, 0, time.UTC)
+	mockClock.On("Now").Return(mock_now_time)
+
+	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
+		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil)
+	mockClock.On("Since", mock_now_time).Return(WAIT_FOR_STATUS_TIMEOUT + time.Microsecond*100)
+
 	err := driver.Restart()
 	assert.ErrorIs(t, err, rebootError)
 }
@@ -2176,7 +2187,7 @@ func TestRestartFailWaitForStatus(t *testing.T) {
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil)
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil).Once()
 	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
 		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil)
 

--- a/pkg/drivers/fsas/fsas_test.go
+++ b/pkg/drivers/fsas/fsas_test.go
@@ -2120,19 +2120,16 @@ func TestRestartSuccess(t *testing.T) {
 		FabricManager: mockFM,
 		Keycloak:      mockKeycloak,
 	}
+
 	mockKeycloak.On("IsInit").Return(true)
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
-	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil).Once()
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
-		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", int(BOOTING), nil).Once()
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
-		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", int(ACTIVE_PON), nil).Once()	
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).
+		Return(nil).Once()
 
 	err := driver.Restart()
 	assert.NoError(t, err)
-
 }
 
 func TestRestartFailReboot(t *testing.T) {
@@ -2149,58 +2146,17 @@ func TestRestartFailReboot(t *testing.T) {
 		FabricManager: mockFM,
 		Keycloak:      mockKeycloak,
 	}
+
 	mockKeycloak.On("IsInit").Return(true)
 	mockFM.On("IsInit").Return(true)
 	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
 
 	rebootError := fmt.Errorf("FM reboot failed")
-	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(rebootError).Once()
-
-	mockClock := timeutilsmock.NewMockClock(t)
-	statusClock = mockClock
-	mock_now_time := time.Date(2025, time.January, 1, 12, 0, 0, 0, time.UTC)
-	mockClock.On("Now").Return(mock_now_time)
-
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
-		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil)
-	mockClock.On("Since", mock_now_time).Return(WAIT_FOR_STATUS_TIMEOUT + time.Microsecond*100)
+	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).
+		Return(rebootError).Once()
 
 	err := driver.Restart()
 	assert.ErrorIs(t, err, rebootError)
-}
-
-func TestRestartFailWaitForStatus(t *testing.T) {
-	mockFM := fmmock.NewMockFabricManager(t)
-	mockKeycloak := keycloakMock.NewMockKeycloak(t)
-
-	driver := &Driver{
-		BaseDriver: &drivers.BaseDriver{
-			IPAddress: "10.1.2.3",
-			SSHUser:   "user-1",
-		},
-		SSHPassword:   "password1",
-		MachineUUID:   "cdd792f2-5591-4c18-a8bd-1c39e55dedfa",
-		FabricManager: mockFM,
-		Keycloak:      mockKeycloak,
-	}
-	mockKeycloak.On("IsInit").Return(true)
-	mockFM.On("IsInit").Return(true)
-	mockKeycloak.On("GetToken").Return(models.AccessTokenExample)
-
-	mockFM.On("Reboot", driver.MachineUUID, driver.TenantUuid, models.AccessTokenExample).Return(nil).Once()
-	mockFM.On("GetMachineDetails", driver.TenantUuid, driver.MachineUUID, models.AccessTokenExample).
-		Return(models.ExpectedLanports, "3129cbdf-345c-43a9-b4dc-34880ceed63d", 99, nil)
-
-	mockClock := timeutilsmock.NewMockClock(t)
-	statusClock = mockClock
-	mock_now_time := time.Date(2025, time.January, 1, 12, 0, 0, 0, time.UTC)
-	mockClock.On("Now").Return(mock_now_time)
-	mockClock.On("Since", mock_now_time).Return(WAIT_FOR_STATUS_TIMEOUT + time.Microsecond*100)
-
-	err := driver.Restart()
-
-	assert.Error(t, err)
-	assert.EqualError(t, err, "error: required status was not achieved within the specified time")
 }
 
 func TestRestartFailEmptyMachineUUID(t *testing.T) {


### PR DESCRIPTION
### **+++task/3363:**

Logs from mock environment during testing of `/reboot`, `/graceful`, and `/pon`:


### **/graceful**

```
curl -k -X PUT "https://cdi.localdomain/fabric_manager/api/v1/machines/56c7311c-3f7c-452e-a55c-dcbfd4817e50/graceful?tenant_uuid=12345678-1234-1234-1234-123456789012"

{"data":{"machines":[{"mach_uuid":"56c7311c-3f7c-452e-a55c-dcbfd4817e50"}]}}
```


### **/pon**

```
curl -k -X PUT "https://cdi.localdomain/fabric_manager/api/v1/machines/56c7311c-3f7c-452e-a55c-dcbfd4817e50/pon?tenant_uuid=12345678-1234-1234-1234-123456789012"

{"data":{"machines":[{"mach_uuid":"56c7311c-3f7c-452e-a55c-dcbfd4817e50"}]}}
```

Verification:

```
curl -k "https://cdi.localdomain/fabric_manager/api/v1/machines/56c7311c-3f7c-452e-a55c-dcbfd4817e50?tenant_uuid=..."

"mach_status":13
```


### **/reboot**

API calls:

```
curl -k -X PUT "https://cdi.localdomain/fabric_manager/api/v1/machines/95e647d0-b9f3-4963-92c5-c11520871884/reboot?tenant_uuid=12345678-1234-1234-1234-123456789012"

{"data":{"machines":[{"mach_uuid":"95e647d0-b9f3-4963-92c5-c11520871884"}]}}
```

Verification:

```
curl -k "https://cdi.localdomain/fabric_manager/api/v1/machines/95e647d0-b9f3-4963-92c5-c11520871884?tenant_uuid=12345678-1234-1234-1234-123456789012"
```

MFM logs:

```
[INFO]; libvirt_handler:462; Reboot was sent to machine 'ia4_wk_hm6bw_d8rxp' successfully
[INFO]; libvirt_handler:462; Reboot was sent to machine 'ia4_wk_hm6bw_d8rxp' successfully
```

OS-level verification:

```
ssh rancher@192.168.122.179 'who -b'
         system boot  2026-04-08 17:43
```

After reboot:

```
ssh rancher@192.168.122.179 'who -b'
         system boot  2026-04-08 17:52
```

During reboot:

```
ssh: connect to host 192.168.122.179 port 22: Connection refused
```


These logs confirm:

* All three endpoints were successfully invoked
* `/reboot` triggered actual VM restart (validated via SSH interruption and updated boot time)
* `/pon` updated machine state (`mach_status: 13`)
* `/graceful` executed without errors

